### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Board Status](https://paolinidesign15.visualstudio.com/3d8001b4-3151-4729-820a-5cba5a47a543/fc381128-7c8d-44f5-b8a6-e5fef53c1376/_apis/work/boardbadge/a8daef09-fe59-4579-9447-0e0ec418e5ee)](https://paolinidesign15.visualstudio.com/3d8001b4-3151-4729-820a-5cba5a47a543/_boards/board/t/fc381128-7c8d-44f5-b8a6-e5fef53c1376/Microsoft.RequirementCategory)
 # coolapp
 Hello word
 # today


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#176](https://paolinidesign15.visualstudio.com/3d8001b4-3151-4729-820a-5cba5a47a543/_workitems/edit/176). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.